### PR TITLE
fix-data-repo-layer-bugs

### DIFF
--- a/openspec/changes/fix-data-repo-layer-bugs/.openspec.yaml
+++ b/openspec/changes/fix-data-repo-layer-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/fix-data-repo-layer-bugs/design.md
+++ b/openspec/changes/fix-data-repo-layer-bugs/design.md
@@ -1,0 +1,136 @@
+## Context
+
+`packages/roombooker_core/lib/data/repos/` was recently documented (spec
+`data-repo-layer`) by reading the existing implementations as-built. That
+read-through found four independent bugs across `log_repo.dart`,
+`user_repo.dart`, `org_repo.dart`, and `booking_repo.dart`. All four are
+small, localized fixes with no shared mechanism between them; this design
+covers each in turn. `fake_cloud_firestore` is already used by
+`booking_repo_test.dart`, `org_repo_test.dart`, and `user_repo_test.dart`, so
+each fix can be covered by a focused unit test.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `LogRepo.addLogEntry` genuinely propagate Firestore write errors as a
+  failed `Future`, so `BookingRepo._log`'s existing `catch`/`rethrow` works
+  as the spec already describes.
+- Make `UserRepo.addOrg` use the `Transaction` it's given (read+write via
+  `t`), and make both `OrgRepo` call sites `await` it.
+- Make `OrgRepo.removeOrg` delete the org document via `t.delete` so the
+  whole operation is atomic and retry-safe.
+- Make `null` recurring-edit choices true no-ops in both
+  `BookingRepo.updateBooking` and `BookingRepo.deleteBooking`.
+
+**Non-Goals:**
+- No changes to `RoomRepo`, `PreferencesRepo`, or the public method
+  signatures of any repo (return types stay `Future<...>`/`Stream<...>` as
+  today).
+- Not addressing `BookingRepo.DetailCache`'s `requestID`-only cache key
+  (practically safe given Firestore's globally-unique push IDs; not a bug
+  worth the churn here).
+- Not changing `OrgRepo.addOrgForCurrentUser`'s best-effort (non-transactional,
+  catch-and-log) creation of the first `Room` — that's a separate, lower-risk
+  gap not raised by this review.
+
+## Decisions
+
+### 1. `LogRepo.addLogEntry` — await and propagate
+
+Change:
+```dart
+await db.collection("orgs").doc(orgID).collection("request-logs")
+    .add(entry.toJson());
+```
+Drop the `.catchError` that `throw`s into a detached future — once awaited,
+a failure naturally completes `addLogEntry`'s `Future` with an error, which
+is exactly what `BookingRepo._log`'s `try { await logRepo.addLogEntry(...); }
+catch (e, s) { log(...); rethrow; }` already expects.
+
+**Alternative considered**: keep `.catchError` but `await` the chain. Rejected
+— redundant once awaited; a plain `await` lets the error surface naturally
+and is simpler.
+
+### 2. `UserRepo.addOrg` — use the transaction, await call sites
+
+Change `addOrg`'s body to use `t.get(profileRef)` and `t.set`/`t.update`
+instead of `profileRef.get()`/`profileRef.set()`. Since Firestore transactions
+require all reads before any writes, and `addOrg` is called *after* other
+reads/writes have already happened in both call sites
+(`addOrgForCurrentUser`, `addAdminRequestForCurrentUser`), this requires
+re-ordering: do `addOrg`'s `t.get` first (or restructure so all transaction
+reads happen up front), then perform the dependent writes.
+
+Concretely:
+- `addOrgForCurrentUser`: read the user profile via `t` *before* `t.add`-ing
+  the new org doc (note: `_db.collection("orgs").add(...)` is itself
+  *not* a transactional write — `CollectionReference.add` has no transaction
+  variant. Use `t.set` on a pre-allocated `doc()` reference instead, so the
+  org-doc creation is part of the same transaction as the profile update).
+- `addAdminRequestForCurrentUser`: read the user profile via `t` before
+  `t.set`-ing the admin-request doc.
+
+Both call sites change `_userRepo.addOrg(t, ...)` (fire-and-forget) to
+`await _userRepo.addOrg(t, ...)`.
+
+**Alternative considered**: leave `addOrg` non-transactional but `await` it
+after the transaction commits (two sequential operations). Rejected — this
+keeps the user-profile update non-atomic with the triggering write, which is
+the core bug; doing the read-then-write inside the same transaction is not
+materially more complex here since both call sites already use
+`runTransaction`.
+
+### 3. `OrgRepo.removeOrg` — transactional delete
+
+Change `await orgRef.delete()` to `t.delete(orgRef)`. Combined with the
+existing `t.get(orgRef)` existence check and `_userRepo.removeOrg(t, ...)`
+(already uses `t.update`), the whole operation becomes a single atomic
+transaction: if it retries, the org doc hasn't actually been deleted yet on
+the retried attempt, so `org.exists` is still accurate.
+
+### 4. `BookingRepo` — true no-ops for `null` edit choice
+
+- `deleteBooking`: replace `case null: throw UnimplementedError();` with
+  `case null: return;` *and* skip the `_log(...)` call entirely for this
+  case (move the `_log` call out of the shared `finally` for the `null`
+  branch, or early-return before entering the `try/finally`).
+- `updateBooking` / `_updateConfirmedBooking`: when `choice == null`,
+  propagate a signal (e.g. a sentinel/flag, or restructure so
+  `_updateConfirmedBooking` returning early causes `updateBooking` to skip
+  both the `t.set(privateDetailsRef, ...)` and the post-transaction `_log`
+  call). Simplest approach: have `_updateConfirmedBooking` return a `bool`
+  (`true` if it made changes), and have `updateBooking` skip the
+  `privateDetailsRef` write and `_log` call when it returns `false` for the
+  confirmed-with-recurrence-and-null-choice case. The `pending`-status branch
+  and the non-recurring confirmed branch always return `true`.
+
+**Alternative considered**: throw a dedicated `BookingEditCancelledException`
+and catch it in `updateBooking`/`deleteBooking` to skip side effects.
+Rejected — using exceptions for normal user-cancellation control flow is
+noisier than a boolean return / early return, and the existing `catch` blocks
+already exist for genuine errors.
+
+## Risks / Trade-offs
+
+- [LogRepo error propagation is a **BREAKING** change to `addLogEntry`'s
+  contract — any caller relying on it never throwing will now see errors] →
+  Only one caller exists today (`BookingRepo._log`), which already has a
+  `try/catch`+`rethrow`; no other change needed. Covered by the proposal's
+  Impact note.
+- [Reordering reads-before-writes in `addOrgForCurrentUser` /
+  `addAdminRequestForCurrentUser` changes transaction read-write ordering,
+  which Firestore transactions enforce strictly] → Write a unit test with
+  `fake_cloud_firestore` for each path to confirm the transaction still
+  commits successfully end-to-end.
+- [`updateBooking`'s no-op path changing from "always writes privateDetails +
+  logs" to "writes nothing" could be surprising if some caller depended on
+  the audit-log side effect even for cancelled edits] → No such dependency
+  found in `BookingService` or UI callers during this review; flagged in
+  proposal Impact for a final check during implementation.
+
+## Migration Plan
+
+No data migration. Roll out as a normal code change; existing Firestore data
+and collection layouts are unaffected. Update the four repo unit test files
+to cover the new behaviors (transactional atomicity, error propagation,
+no-op paths).

--- a/openspec/changes/fix-data-repo-layer-bugs/proposal.md
+++ b/openspec/changes/fix-data-repo-layer-bugs/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+While backfilling the `data-repo-layer` spec (see archived change
+`spec-data-repo-layer`), cross-checking the spec against
+`packages/roombooker_core/lib/data/repos/` surfaced several real correctness
+bugs in the repo implementations themselves (not just spec inaccuracies):
+silent/unobservable logging failures, non-transactional writes presented as
+atomic, a dangling-reference hazard on org removal, and two "no-op" recurring
+booking edit paths that aren't actually no-ops. These should be fixed now,
+before more code is built on top of the documented (but incorrect) contracts.
+
+## What Changes
+
+- **LogRepo.addLogEntry**: `await` and `return` the underlying Firestore
+  `.add()` call so write failures actually propagate to callers (currently
+  the failure is dropped into a detached `Future` via an unawaited
+  `.catchError` that `throw`s, producing an unhandled async error instead of
+  the documented "error is rethrown to the caller" behavior). **BREAKING**:
+  `addLogEntry`'s `Future<void>` now genuinely completes with an error when
+  the Firestore write fails, where previously it always completed
+  successfully.
+- **UserRepo.addOrg**: make it actually use the supplied `Transaction` (via
+  `t.get`/`t.set`) instead of issuing a separate non-transactional
+  `get()`/`set()`, and `await` it at both call sites
+  (`OrgRepo.addOrgForCurrentUser`, `OrgRepo.addAdminRequestForCurrentUser`)
+  so the org-membership update is atomic with, and observable alongside, the
+  surrounding write.
+- **OrgRepo.removeOrg**: perform the `orgs/{orgID}` document delete via the
+  transaction (`t.delete`) instead of a direct, non-transactional
+  `.delete()`, so a transaction retry can't leave the org deleted but the
+  user's `orgIDs` still referencing it.
+- **BookingRepo.deleteBooking**: when the `RecurringBookingEditChoiceProvider`
+  resolves to `null` (user cancelled), return without throwing
+  `UnimplementedError` and without writing an audit log entry — cancellation
+  is a legitimate no-op, not an unimplemented code path.
+- **BookingRepo.updateBooking**: when the edit-choice provider resolves to
+  `null` for a recurring confirmed request, make the entire operation a true
+  no-op — skip the `privateDetails` write and the `UpdateBooking` audit log
+  entry/analytics event, matching the "no Firestore writes, no-op" intent.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `data-repo-layer`:
+  - "Audit Logging and Analytics on Booking Mutations": logging failures
+    SHALL propagate as real errors from `LogRepo.addLogEntry`.
+  - "Recurring Booking Edit Choice Handling": a `null` edit choice SHALL be a
+    true no-op for both `updateBooking` and `deleteBooking` (no writes, no
+    audit log entries, no thrown errors).
+  - "Organization CRUD and Visibility": `removeOrg` SHALL delete the org
+    document and update the user's `orgIDs` within the same atomic
+    transaction.
+  - "Admin Request Workflow" and "User Profile and Org Membership":
+    `UserRepo.addOrg` SHALL perform its read/write through the caller's
+    `Transaction`, and callers SHALL await it.
+
+## Impact
+
+- **Affected code**:
+  `packages/roombooker_core/lib/data/repos/{log_repo,user_repo,org_repo,booking_repo}.dart`
+  and their tests.
+- **Affected specs**: Modifies `openspec/specs/data-repo-layer/spec.md`
+  (requirements listed above).
+- **Risk**: `LogRepo.addLogEntry` becoming a real failure path means
+  `BookingRepo._log`'s existing `try/catch`+`rethrow` will now actually
+  trigger on logging failures, which already rethrows to the booking
+  mutation's caller (per the existing documented contract) — callers of
+  booking mutations should already be prepared for this, but should be
+  re-checked.

--- a/openspec/changes/fix-data-repo-layer-bugs/specs/data-repo-layer/spec.md
+++ b/openspec/changes/fix-data-repo-layer-bugs/specs/data-repo-layer/spec.md
@@ -1,0 +1,172 @@
+## MODIFIED Requirements
+
+### Requirement: Audit Logging and Analytics on Booking Mutations
+`BookingRepo` SHALL record a corresponding `RequestLogEntry` via
+`LogRepo.addLogEntry` and emit an analytics event with the org ID and
+request ID after the underlying Firestore write completes, for every method
+that mutates a booking request (submit, update, add, end, ignore-overlaps,
+delete, confirm, deny, revisit).
+
+#### Scenario: Mutation succeeds but logging fails
+- **WHEN** a `BookingRepo` mutation's Firestore write succeeds but the
+  underlying `request-logs` Firestore write inside `LogRepo.addLogEntry`
+  fails
+- **THEN** `LogRepo.addLogEntry`'s returned `Future` SHALL complete with that
+  error (rather than completing successfully), and `BookingRepo._log` SHALL
+  log the error via `dart:developer.log` and rethrow it to the caller, even
+  though the underlying data mutation has already been committed.
+
+### Requirement: Recurring Booking Edit Choice Handling
+`BookingRepo.updateBooking` and `BookingRepo.deleteBooking` SHALL, for
+requests whose recurrence frequency is not "never", invoke the supplied
+`RecurringBookingEditChoiceProvider` and apply one of three edit scopes:
+`thisInstance`, `thisAndFuture`, or `all`.
+
+#### Scenario: Editing this instance only
+- **WHEN** `updateBooking` is called for a recurring request with edit
+  choice `thisInstance`
+- **THEN** the original recurring request SHALL gain a
+  `recurranceOverrides` entry keyed by the (stripped-to-day) original start
+  time, mapping to the updated request, and the base recurrence definition
+  SHALL remain unchanged.
+
+#### Scenario: Editing this and future instances
+- **WHEN** `updateBooking` is called for a recurring request with edit
+  choice `thisAndFuture`
+- **THEN** the original recurring request's `recurrancePattern.end` SHALL be
+  set to one day before the updated request's event end date, and a new
+  confirmed-request document SHALL be created representing the updated
+  request as a new (independent) recurring series.
+
+#### Scenario: Editing all instances
+- **WHEN** `updateBooking` is called for a recurring request with edit
+  choice `all`
+- **THEN** the existing confirmed-request document SHALL be overwritten with
+  the updated request's fields while preserving the original request's
+  `eventStartTime` and `eventEndTime`.
+
+#### Scenario: Deleting this instance of a recurring series
+- **WHEN** `deleteBooking` is called for a recurring request with edit choice
+  `thisInstance`
+- **THEN** the original recurring request SHALL gain a
+  `recurranceOverrides` entry keyed by the (stripped-to-day) event start
+  time, mapped to `null`, removing that single occurrence without deleting
+  the series.
+
+#### Scenario: Deleting this and future instances of a recurring series
+- **WHEN** `deleteBooking` is called for a recurring request with edit choice
+  `thisAndFuture`
+- **THEN** `endBooking` SHALL be invoked, setting
+  `recurrancePattern.end` to the (stripped-to-day) `eventStartTime` of the
+  request being deleted.
+
+#### Scenario: No recurring edit choice provided for an update
+- **WHEN** `updateBooking` is called for a recurring confirmed request and the
+  `RecurringBookingEditChoiceProvider` resolves to `null`
+- **THEN** the operation SHALL be a complete no-op: no write SHALL be made to
+  the confirmed-request document or to
+  `orgs/{orgID}/request-details/{requestID}`, and no `UpdateBooking` audit
+  log entry or analytics event SHALL be recorded.
+
+#### Scenario: No recurring edit choice provided for a delete
+- **WHEN** `deleteBooking` is called for a recurring request and the
+  `RecurringBookingEditChoiceProvider` resolves to `null`
+- **THEN** the operation SHALL be a no-op: it SHALL return without throwing
+  and without writing a `DeleteBooking` audit log entry.
+
+### Requirement: Organization CRUD and Visibility
+`OrgRepo` SHALL manage `Organization` documents under the `orgs` collection,
+including creation (with an initial room and the creating user added as a
+member), visibility toggling (`publiclyVisible`), notification settings
+updates, and removal (including removing the org from the owning user's
+`orgIDs`).
+
+#### Scenario: Creating an organization for the current user
+- **WHEN** `addOrgForCurrentUser(orgName, firstRoomName)` is called while a
+  user is authenticated
+- **THEN** a new `orgs` document SHALL be created with `ownerID` set to the
+  current user's UID and `acceptingAdminRequests: false`, the user's
+  `orgIDs` SHALL include the new org's ID, and a first `Room` named
+  `firstRoomName` SHALL be created in `orgs/{orgID}/rooms`.
+
+#### Scenario: Creating an organization while signed out
+- **WHEN** `addOrgForCurrentUser` is called and `FirebaseAuth.currentUser`
+  is `null`
+- **THEN** the returned future SHALL complete with an error and no Firestore
+  writes SHALL occur.
+
+#### Scenario: Removing an organization
+- **WHEN** `removeOrg(orgID)` is called by an authenticated user for an org
+  that exists
+- **THEN** the `orgs/{orgID}` document SHALL be deleted via `t.delete` and
+  the calling user's `orgIDs` SHALL be updated via a transactional
+  `FieldValue.arrayRemove` of `orgID`, both as part of the same atomic
+  transaction, so a transaction retry cannot observe the org as already
+  deleted while the user's `orgIDs` still references it.
+
+#### Scenario: Listing public organizations excludes owned orgs on request
+- **WHEN** `getOrgs(excludeOwned: true)` is called for an authenticated user
+- **THEN** the returned stream SHALL contain only orgs with
+  `publiclyVisible: true` whose IDs are not present in the current user's
+  `orgIDs`.
+
+### Requirement: Admin Request Workflow
+`OrgRepo` SHALL support a request/approve/deny workflow for organization
+admin access, storing pending requests in
+`orgs/{orgID}/admin-requests/{userID}` and approved admins in
+`orgs/{orgID}/active-admins/{userID}`.
+
+#### Scenario: Requesting admin access
+- **WHEN** `addAdminRequestForCurrentUser(orgID)` is called by an
+  authenticated user with an email address
+- **THEN** an `AdminEntry` document SHALL be created at
+  `orgs/{orgID}/admin-requests/{userID}` and the user's `orgIDs` SHALL be
+  updated to include `orgID`, both as part of the same transaction (via
+  `t.get`/`t.set` on `users/{userID}` and `t.set` on the admin-request
+  document).
+
+#### Scenario: Approving an admin request
+- **WHEN** `approveAdminRequest(orgID, userID)` is called for a user with an
+  existing entry in `orgs/{orgID}/admin-requests`
+- **THEN** that entry SHALL be deleted from `admin-requests` and an
+  equivalent `AdminEntry` document SHALL be created at
+  `orgs/{orgID}/active-admins/{userID}`, within a single transaction.
+
+#### Scenario: Approving a request that no longer exists
+- **WHEN** `approveAdminRequest(orgID, userID)` is called but no document
+  exists at `orgs/{orgID}/admin-requests/{userID}`
+- **THEN** the transaction SHALL fail with an error and no documents SHALL
+  be written to `active-admins`.
+
+#### Scenario: Denying an admin request
+- **WHEN** `denyAdminRequest(orgID, userID)` is called
+- **THEN** the document at `orgs/{orgID}/admin-requests/{userID}` SHALL be
+  deleted.
+
+### Requirement: User Profile and Org Membership
+`UserRepo` SHALL manage `UserProfile` documents at `users/{uID}`, each
+tracking the org IDs (`orgIDs`) the user belongs to, and SHALL keep this
+list in sync as the user joins or leaves organizations.
+
+#### Scenario: Creating a profile for a new user
+- **WHEN** `addUser(user)` is called for a user with no existing profile
+- **THEN** a `UserProfile` document SHALL be created at `users/{user.uid}`
+  with an empty `orgIDs` list.
+
+#### Scenario: Adding an org to an existing profile
+- **WHEN** `addOrg(t, userID, orgID)` is called and `users/{userID}` already
+  exists with `orgIDs` not containing `orgID`
+- **THEN** `orgID` SHALL be appended to that profile's `orgIDs` via a read
+  (`t.get`) and write (`t.set`) performed within the supplied transaction
+  `t`.
+
+#### Scenario: Adding an org the user already belongs to
+- **WHEN** `addOrg(t, userID, orgID)` is called and the user's `orgIDs`
+  already contains `orgID`
+- **THEN** the profile SHALL be left unchanged (no duplicate entries, no
+  write performed), using a transactional read (`t.get`) within `t`.
+
+#### Scenario: Removing an org from a profile
+- **WHEN** `removeOrg(t, userID, orgID)` is called
+- **THEN** `orgID` SHALL be removed from `users/{userID}.orgIDs` via an
+  array-remove update.

--- a/openspec/changes/fix-data-repo-layer-bugs/tasks.md
+++ b/openspec/changes/fix-data-repo-layer-bugs/tasks.md
@@ -1,0 +1,54 @@
+## 1. LogRepo error propagation
+
+- [ ] 1.1 In `log_repo.dart`, `await` (and stop swallowing) the
+      `request-logs` `.add()` call in `addLogEntry` so a Firestore write
+      failure completes `addLogEntry`'s `Future` with an error.
+- [ ] 1.2 Add/update a `log_repo_test.dart` (or extend
+      `booking_repo_test.dart`) case covering "Mutation succeeds but logging
+      fails": stub `LogRepo.addLogEntry` (or the underlying Firestore write)
+      to fail and assert the `BookingRepo` mutation rethrows.
+
+## 2. UserRepo.addOrg transactional fix
+
+- [ ] 2.1 In `user_repo.dart`, rewrite `addOrg(Transaction t, userID, orgID)`
+      to read the profile via `t.get` and write via `t.set`/`t.update`
+      instead of non-transactional `profileRef.get()`/`profileRef.set()`.
+- [ ] 2.2 In `org_repo.dart`, update `addOrgForCurrentUser` to perform all
+      transaction reads (including `addOrg`'s profile read) before any
+      writes, replace `_db.collection("orgs").add(...)` with `t.set` on a
+      pre-allocated `doc()` reference, and `await _userRepo.addOrg(t, ...)`.
+- [ ] 2.3 In `org_repo.dart`, update `addAdminRequestForCurrentUser` the same
+      way: read-before-write ordering and `await _userRepo.addOrg(t, ...)`.
+- [ ] 2.4 Update `user_repo_test.dart` and `org_repo_test.dart` to cover the
+      transactional `addOrg` behavior (profile created/updated atomically
+      with the org/admin-request document) using `fake_cloud_firestore`.
+
+## 3. OrgRepo.removeOrg transactional delete
+
+- [ ] 3.1 In `org_repo.dart`, change `removeOrg` to delete the org document
+      via `t.delete(orgRef)` instead of `await orgRef.delete()`.
+- [ ] 3.2 Update `org_repo_test.dart` to confirm `removeOrg` deletes the org
+      doc and updates `users/{uid}.orgIDs` atomically.
+
+## 4. BookingRepo null edit-choice no-ops
+
+- [ ] 4.1 In `booking_repo.dart`, change `deleteBooking`'s `case null:` to
+      return without throwing `UnimplementedError` and without writing a
+      `DeleteBooking` audit log entry (restructure the `try`/`finally` so
+      `_log` is skipped for this case).
+- [ ] 4.2 In `booking_repo.dart`, make `_updateConfirmedBooking` signal
+      "no changes made" when `choice == null` (e.g. return a `bool`), and
+      have `updateBooking` skip the `privateDetailsRef` write and the
+      post-transaction `_log` call when no changes were made.
+- [ ] 4.3 Update `booking_repo_test.dart` to cover both no-op scenarios:
+      `updateBooking`/`deleteBooking` called on a recurring request with the
+      `RecurringBookingEditChoiceProvider` resolving to `null` results in no
+      Firestore writes and no audit log entries.
+
+## 5. Validation
+
+- [ ] 5.1 Run `(cd packages/roombooker_core && flutter test)` and confirm all
+      tests pass.
+- [ ] 5.2 Run `flutter analyze` from the repo root and confirm no new issues.
+- [ ] 5.3 Run `openspec validate fix-data-repo-layer-bugs --strict` and
+      confirm the change's spec delta is valid.


### PR DESCRIPTION
## Why

While backfilling the `data-repo-layer` spec (#15), cross-checking the spec against `packages/roombooker_core/lib/data/repos/` surfaced several real correctness bugs in the repo implementations themselves: silent/unobservable logging failures, non-transactional writes presented as atomic, a dangling-reference hazard on org removal, and two "no-op" recurring booking edit paths that aren't actually no-ops.

## What Changes

- **LogRepo.addLogEntry**: `await`/`return` the Firestore `.add()` call so write failures propagate to callers instead of becoming an unhandled async error. **BREAKING**: `addLogEntry` now genuinely fails when the write fails.
- **UserRepo.addOrg**: use the supplied `Transaction` (via `t.get`/`t.set`) instead of a separate non-transactional read/write, and `await` it at both call sites (`OrgRepo.addOrgForCurrentUser`, `OrgRepo.addAdminRequestForCurrentUser`).
- **OrgRepo.removeOrg**: delete the org doc via `t.delete` instead of a direct, non-transactional `.delete()`, closing a retry hazard that could leave a dangling org ID in the user's `orgIDs`.
- **BookingRepo.deleteBooking**: a `null` recurring-edit choice (user cancelled) is now a true no-op instead of throwing `UnimplementedError` and still logging.
- **BookingRepo.updateBooking**: a `null` recurring-edit choice for a confirmed recurring request is now a true no-op (no `privateDetails` write, no audit log entry/analytics event).

## Dependency

This change's spec delta modifies `openspec/specs/data-repo-layer/spec.md`, added by #15 (`spec-data-repo-layer`). This PR is based on that branch and should be rebased onto `main` once #15 merges.

## Test plan
- [ ] `(cd packages/roombooker_core && flutter test)`
- [ ] `flutter analyze`
- [ ] `openspec validate fix-data-repo-layer-bugs --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)