### PR TITLE
chore: normalize main-spec headers for 5 leftover delta specs

### DIFF
--- a/openspec/specs/dual-display-orchestration/spec.md
+++ b/openspec/specs/dual-display-orchestration/spec.md
@@ -1,4 +1,14 @@
-## ADDED Requirements
+# Dual-Display Orchestration Specification: Room Booker
+
+## Purpose
+This document specifies how the Kiosk application detects and orchestrates
+its Tablet (Controller) and TV (Stage) displays for dual-display
+meeting-room setups, including display lifecycle management.
+
+## [DUAL-000] Compliance
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Requirements
 
 ### Requirement: Display Detection and Role Assignment
 The Kiosk application MUST detect the presence of a secondary display (HDMI/USB-C) and automatically assign display roles.

--- a/openspec/specs/kiosk-provisioning/spec.md
+++ b/openspec/specs/kiosk-provisioning/spec.md
@@ -1,4 +1,14 @@
-## ADDED Requirements
+# Kiosk Provisioning Specification: Room Booker
+
+## Purpose
+This document specifies how Kiosk devices are linked to a room and
+organization via an activation code, how that identity is persisted and
+verified, and the security/UX guarantees around (de)provisioning.
+
+## [PROV-000] Compliance
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Requirements
 
 ### Requirement: Activation Handshake
 The system MUST use a 6-digit numeric activation code to securely link a new hardware device to a specific room and organization.

--- a/openspec/specs/pr-review-workflow/spec.md
+++ b/openspec/specs/pr-review-workflow/spec.md
@@ -1,4 +1,13 @@
-## ADDED Requirements
+# PR Review Workflow Specification: Room Booker
+
+## Purpose
+This document specifies the branch-per-change, draft-PR, self-review, and
+archive/merge process used for OpenSpec changes in this project.
+
+## [PRWF-000] Compliance
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Requirements
 
 ### Requirement: Branch and Draft PR per Change
 Each OpenSpec change SHALL be developed on its own dedicated branch, with a
@@ -29,8 +38,8 @@ reflects progress.
   `tasks.md`, SHALL be committed and pushed to the change's branch.
 
 ### Requirement: Self-Review Before Ready for Review
-Before a change's PR is marked ready for human review, a self-review of the
-PR's diff SHALL be performed and any resulting high-confidence fixes applied.
+A self-review of a change's PR diff SHALL be performed, with high-confidence
+fixes applied, before the PR is marked ready for human review.
 
 #### Scenario: Self-review runs after all tasks complete
 - **WHEN** all tasks in `tasks.md` are marked complete
@@ -50,9 +59,9 @@ same branch.
   change's existing branch without rewriting prior commit history.
 
 ### Requirement: Archive as Final Pre-Merge Step
-Merging a change's spec deltas into the canonical specs and archiving the
-change directory SHALL occur as the final commit on the change's branch,
-after the user has approved the PR and before it is merged.
+A change's spec deltas SHALL be merged into the canonical specs and its
+change directory archived as the final commit on the change's branch, after
+the user has approved the PR and before it is merged.
 
 #### Scenario: Archive performed after approval
 - **WHEN** the user approves a change's PR and requests it be archived

--- a/openspec/specs/privacy-stance/spec.md
+++ b/openspec/specs/privacy-stance/spec.md
@@ -1,4 +1,14 @@
-## ADDED Requirements
+# Privacy Stance Specification: Room Booker
+
+## Purpose
+This document specifies the application's privacy posture regarding
+advertising identifiers and demographic tracking, and the build/runtime
+guarantees that enforce it.
+
+## [PRIV-000] Compliance
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Requirements
 
 ### Requirement: Exclusion of Advertising Identifiers
 The system SHALL NOT collect or transmit the Android Advertising ID (AD_ID) for any purpose.

--- a/openspec/specs/version-driven-cd/spec.md
+++ b/openspec/specs/version-driven-cd/spec.md
@@ -1,4 +1,13 @@
-## ADDED Requirements
+# Version-Driven CD Specification: Room Booker
+
+## Purpose
+This document specifies how semantic version tags route Android builds to
+Google Play Internal/Production deployment tracks via the CI/CD pipeline.
+
+## [CD-000] Compliance
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Requirements
 
 ### Requirement: Semantic Version Routing
 The CI/CD pipeline MUST route application builds to specific deployment tracks based on the semantic versioning tag that triggered the build.


### PR DESCRIPTION
## Summary
- Adds the standard H1 title, `## Purpose`, and `## [PREFIX-000] Compliance` sections to 5 main specs that were left with the delta-format `## ADDED Requirements` header after being archived (`dual-display-orchestration`, `kiosk-provisioning`, `pr-review-workflow`, `privacy-stance`, `version-driven-cd`).
- Converts `## ADDED Requirements` to `## Requirements` so these specs are correctly parsed by `openspec list --specs` (previously misreported as 0 requirements) and pass `openspec validate --strict`.
- Rewords two `pr-review-workflow` requirement summaries so their first line contains a SHALL/MUST keyword, satisfying the validator.

## Test plan
- [x] `openspec list --specs` now reports correct requirement counts for all 5 specs (4, 5, 7, 3, 1 respectively)
- [x] `openspec validate <spec> --strict --type spec` passes for all 5