### PR TITLE
fix: store provisioning code expiresAt as UTC

### DIFF
--- a/packages/roombooker_core/lib/data/services/provisioning_service.dart
+++ b/packages/roombooker_core/lib/data/services/provisioning_service.dart
@@ -25,7 +25,9 @@ class ProvisioningService {
     required String roomName,
   }) async {
     final code = _generateRandomCode();
-    final expiresAt = DateTime.now().add(const Duration(minutes: 10));
+    final expiresAt = DateTime.now().toUtc().add(
+      const Duration(minutes: 10),
+    );
 
     final handshake = ProvisioningHandshake(
       code: code,

--- a/packages/roombooker_core/test/data/services/provisioning_service_test.dart
+++ b/packages/roombooker_core/test/data/services/provisioning_service_test.dart
@@ -38,6 +38,27 @@ void main() {
       expect(doc.data()!['roomName'], 'Sanctuary');
     });
 
+    test('createActivationCode stores expiresAt as a UTC timestamp', () async {
+      final code = await service.createActivationCode(
+        orgID: 'org-123',
+        orgName: 'My Church',
+        roomID: 'room-456',
+        roomName: 'Sanctuary',
+      );
+
+      final doc = await firestore.collection('provisioning_codes').doc(code).get();
+      final expiresAt = doc.data()!['expiresAt'] as String;
+
+      // Must be unambiguously UTC (trailing 'Z') so the claimKioskGrant
+      // Cloud Function (running in Node, which treats offset-less
+      // datetime strings as local time) doesn't misinterpret a non-UTC
+      // device-local timestamp as already expired.
+      expect(expiresAt, endsWith('Z'));
+
+      final parsed = DateTime.parse(expiresAt);
+      expect(parsed.isAfter(DateTime.now().toUtc()), true);
+    });
+
     test('claimKioskGrant calls the callable and returns a KioskGrant', () async {
       final functions = MockFirebaseFunctions();
       final callable = MockHttpsCallable();


### PR DESCRIPTION
## Summary
- `ProvisioningService.createActivationCode` built `expiresAt` from `DateTime.now()` (device-local) and serialized it via `toIso8601String()`, which omits a timezone suffix for local `DateTime`s.
- The `claimKioskGrant` Cloud Function (Node, running in UTC) parses that offset-less string as UTC, so for devices west of UTC the computed expiry is several hours in the past — freshly-generated activation codes are immediately rejected as expired.

## Fix
- Use `DateTime.now().toUtc()` so the serialized `expiresAt` ends in `Z` and is parsed unambiguously.

## Test plan
- [x] Added a test asserting the stored `expiresAt` ends in `Z` and is in the future relative to `DateTime.now().toUtc()`.
- [x] `(cd packages/roombooker_core && flutter test)` — all 131 tests pass.
- [x] `flutter analyze` — no issues.